### PR TITLE
Fix broken E2E tests

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -5,6 +5,16 @@ COPY . /tests
 RUN apt-get update && \
     apt-get install -y jq
 
+nuts-node:
+    COPY /nuts-node/ /nuts-node/
+    WORKDIR /nuts-node
+
+    RUN ls -lisah .
+
+    FROM DOCKERFILE .
+
+    SAVE IMAGE nuts-node
+
 network-direct-wan:
     WORKDIR /tests/nuts-network/direct-wan
 

--- a/Earthfile
+++ b/Earthfile
@@ -5,16 +5,6 @@ COPY . /tests
 RUN apt-get update && \
     apt-get install -y jq
 
-nuts-node:
-    COPY /nuts-node/ /nuts-node/
-    WORKDIR /nuts-node
-
-    RUN ls -lisah .
-
-    FROM DOCKERFILE .
-
-    SAVE IMAGE nuts-node
-
 network-direct-wan:
     WORKDIR /tests/nuts-network/direct-wan
 

--- a/oauth-flow/run-test.sh
+++ b/oauth-flow/run-test.sh
@@ -128,7 +128,7 @@ echo "------------------------------------"
 # Create JWT bearer token
 VP=$(cat ./node-B/data/vp.txt)
 REQUEST="{\"custodian\":\"${VENDOR_A_DID}\",\"actor\":\"${VENDOR_B_DID}\",\"identity\":\"${VP}\",\"service\":\"test\"}"
-RESPONSE=$(echo $REQUEST | curl -X POST -s --data-binary @- http://localhost:21323/internal/auth/v1/bearertoken -H "Content-Type:application/json")
+RESPONSE=$(echo $REQUEST | curl -X POST -s --data-binary @- http://localhost:21323/internal/auth/v1/jwt-grant -H "Content-Type:application/json")
 echo $RESPONSE
 if echo $RESPONSE | grep -q "bearer_token"; then
   echo $RESPONSE | sed -E 's/.*"bearer_token":"([^"]*).*/\1/' > ./node-B/data/bearertoken.txt


### PR DESCRIPTION
For now, quickfix for the E2E tests after introducing the new oauth2 flow. This works just fine but the next step is to test if we can get an access-token in one HTTP call. In theory this works but because of missing TLS config we cant test this yet. I'm working on that but in the meantime it would be nice to have working E2E tests...