### PR TITLE
Set min TLS version in nginx to 1.3

### DIFF
--- a/oauth-flow/node-A/nginx.conf
+++ b/oauth-flow/node-A/nginx.conf
@@ -36,6 +36,7 @@ http {
       ssl_client_certificate    /etc/nginx/ssl/truststore.pem;
       ssl_verify_client         on;
       ssl_verify_depth          1;
+      ssl_protocols             TLSv1.3;
 
       location / {
         proxy_set_header X-Ssl-Client-Cert $ssl_client_escaped_cert;


### PR DESCRIPTION
Fix for minimal TLS version in nuts-node