### PR TITLE
Add E2E test for private transactions

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -11,7 +11,24 @@ network-direct-wan:
     WITH DOCKER \
         --compose docker-compose.yml
         RUN ./run-test.sh
+    END \
+
+private-transactions-prepare:
+    WORKDIR /tests/nuts-network/private-transactions
+
+    WITH DOCKER \
+        --compose docker-compose.yml
+        RUN ./prepare.sh
     END
+
+private-transactions:
+    FROM +private-transactions-prepare
+    WORKDIR /tests/nuts-network/private-transactions
+
+    WITH DOCKER \
+        --compose docker-compose.yml
+        RUN ./run-test.sh
+    END \
 
 network-ssloffloading:
     WORKDIR /tests/nuts-network/ssl-offloading

--- a/nuts-network/private-transactions/docker-compose.yml
+++ b/nuts-network/private-transactions/docker-compose.yml
@@ -1,0 +1,28 @@
+version: "3.7"
+services:
+  nodeA:
+    image: nutsfoundation/nuts-node:master
+    environment:
+      NUTS_CONFIGFILE: /opt/nuts/nuts.yaml
+    ports:
+      - "11323:1323"
+    volumes:
+      - "./node-A/data:/opt/nuts/data"
+      - "./node-A/nuts.yaml:/opt/nuts/nuts.yaml:ro"
+      - "../../tls-certs/nodeA-certificate.pem:/opt/nuts/certificate-and-key.pem:ro"
+      - "../../tls-certs/truststore.pem:/opt/nuts/truststore.pem:ro"
+    healthcheck:
+      interval: 1s # Make test run quicker by checking health status more often
+  nodeB:
+    image: nutsfoundation/nuts-node:master
+    environment:
+      NUTS_CONFIGFILE: /opt/nuts/nuts.yaml
+    ports:
+      - "21323:1323"
+    volumes:
+      - "./node-B/data:/opt/nuts/data"
+      - "./node-B/nuts.yaml:/opt/nuts/nuts.yaml:ro"
+      - "../../tls-certs/nodeB-certificate.pem:/opt/nuts/certificate-and-key.pem:ro"
+      - "../../tls-certs/truststore.pem:/opt/nuts/truststore.pem:ro"
+    healthcheck:
+      interval: 1s # Make test run quicker by checking health status more often

--- a/nuts-network/private-transactions/node-A/nuts.yaml
+++ b/nuts-network/private-transactions/node-A/nuts.yaml
@@ -12,6 +12,8 @@ auth:
 vcr:
   overrideissueallpublic: false
 network:
+  v1:
+    adverthashesinterval: 250
   publicaddr: nodeA:5555
   grpcaddr:	:5555
   truststorefile: /opt/nuts/truststore.pem

--- a/nuts-network/private-transactions/node-A/nuts.yaml
+++ b/nuts-network/private-transactions/node-A/nuts.yaml
@@ -1,0 +1,19 @@
+verbosity: debug
+datadir: /opt/nuts/data
+http:
+  default:
+    address: :1323
+auth:
+  publicurl: http://node-A
+  contractvalidators:
+    - dummy
+  irma:
+    autoupdateschemas: false
+vcr:
+  overrideissueallpublic: false
+network:
+  publicaddr: nodeA:5555
+  grpcaddr:	:5555
+  truststorefile: /opt/nuts/truststore.pem
+  certfile: /opt/nuts/certificate-and-key.pem
+  certkeyfile: /opt/nuts/certificate-and-key.pem

--- a/nuts-network/private-transactions/node-B/nuts.yaml
+++ b/nuts-network/private-transactions/node-B/nuts.yaml
@@ -1,0 +1,20 @@
+verbosity: debug
+datadir: /opt/nuts/data
+http:
+  default:
+    address: :1323
+auth:
+  publicurl: http://node-B
+  contractvalidators:
+    - dummy
+  irma:
+    autoupdateschemas: false
+vcr:
+  overrideissueallpublic: false
+network:
+  bootstrapnodes: nodeA:5555
+  publicaddr: nodeB:5555
+  grpcaddr:	:5555
+  truststorefile: /opt/nuts/truststore.pem
+  certfile: /opt/nuts/certificate-and-key.pem
+  certkeyfile: /opt/nuts/certificate-and-key.pem

--- a/nuts-network/private-transactions/node-B/nuts.yaml
+++ b/nuts-network/private-transactions/node-B/nuts.yaml
@@ -12,6 +12,8 @@ auth:
 vcr:
   overrideissueallpublic: false
 network:
+  v1:
+    adverthashesinterval: 250
   bootstrapnodes: nodeA:5555
   publicaddr: nodeB:5555
   grpcaddr:	:5555

--- a/nuts-network/private-transactions/prepare.sh
+++ b/nuts-network/private-transactions/prepare.sh
@@ -7,6 +7,7 @@ source ../../util.sh
 function setupNode() {
   local did=$(printf '{
     "selfControl": true,
+    "keyAgreement": true,
     "assertionMethod": true,
     "capabilityInvocation": true
   }' | curl -s -X POST "$1/internal/vdr/v1/did" -H "Content-Type: application/json" --data-binary @- | jq -r ".id")

--- a/nuts-network/private-transactions/prepare.sh
+++ b/nuts-network/private-transactions/prepare.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+set -e
+
+source ../../util.sh
+
+function setupNode() {
+  local did=$(printf '{
+    "selfControl": true,
+    "assertionMethod": true,
+    "capabilityInvocation": true
+  }' | curl -s -X POST "$1/internal/vdr/v1/did" -H "Content-Type: application/json" --data-binary @- | jq -r ".id")
+
+  printf '{
+    "type": "NutsComm",
+    "endpoint": "grpc://%s"
+  }' "$2" | curl -s -X POST "$1/internal/didman/v1/did/$did/endpoint" -H "Content-Type: application/json" --data-binary @- > /dev/null
+
+  echo "$did"
+}
+
+echo "------------------------------------"
+echo "Cleaning up running Docker containers and volumes, and key material..."
+echo "------------------------------------"
+
+docker-compose down
+docker-compose rm -f -v
+
+echo "------------------------------------"
+echo "Starting Docker containers..."
+echo "------------------------------------"
+
+docker-compose up -d
+
+waitForDCService nodeA
+waitForDCService nodeB
+
+# Wait for Nuts Network nodes to build connections
+sleep 5
+
+echo "------------------------------------"
+echo "Creating NodeDIDs..."
+echo "------------------------------------"
+
+didNodeA=$(setupNode "http://localhost:11323" "nodeA:5555")
+printf "NodeDID for node-a: %s\n" "$didNodeA"
+
+# Wait for the transactions to be processed (will be the root transaction for both nodes)
+sleep 5
+
+didNodeB=$(setupNode "http://localhost:21323" "nodeB:5555")
+printf "NodeDID for node-b: %s\n" "$didNodeB"
+
+# Wait for the transactions to be processed
+sleep 5
+
+echo "" >> node-A/nuts.yaml
+echo "  nodedid: $didNodeA" >> node-A/nuts.yaml
+echo "" >> node-B/nuts.yaml
+echo "  nodedid: $didNodeB" >> node-B/nuts.yaml

--- a/nuts-network/private-transactions/run-test.sh
+++ b/nuts-network/private-transactions/run-test.sh
@@ -66,7 +66,7 @@ if [ $(searchAuthCredentials "http://localhost:11323" | jq "length") -ne 2 ]; th
 fi
 
 if [ $(searchAuthCredentials "http://localhost:21323" | jq "length") -ne 2 ]; then
-  echo "failed to find NutsAuthorizationCredentials on Node-A"
+  echo "failed to find NutsAuthorizationCredentials on Node-B"
   exit 1
 fi
 

--- a/nuts-network/private-transactions/run-test.sh
+++ b/nuts-network/private-transactions/run-test.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+set -e
+
+source ../../util.sh
+
+function findNodeDID() {
+  egrep -o 'nodedid:.*' $1 | awk '{print $2}'
+}
+
+function createAuthCredential() {
+  printf '{
+    "type": "NutsAuthorizationCredential",
+    "issuer": "%s",
+    "credentialSubject": {
+      "id": "%s",
+      "legalBase": {
+        "consentType": "implied"
+      },
+      "resources": [],
+      "purposeOfUse": "example",
+      "subject": "urn:oid:2.16.840.1.113883.2.4.6.3:123456780"
+    }
+  }' "$2" "$3" | curl -s -X POST "$1/internal/vcr/v1/vc" -H "Content-Type: application/json" --data-binary @- > /dev/null
+}
+
+function searchAuthCredentials() {
+  printf '{
+    "params": [{
+      "key": "credentialSubject.subject",
+      "value": "urn:oid:2.16.840.1.113883.2.4.6.3:123456780"
+    }]
+  }' | curl -s -X POST "$1/internal/vcr/v1/authorization?untrusted=true" -H "Content-Type: application/json" --data-binary @-
+}
+
+echo "------------------------------------"
+echo "Starting Docker containers..."
+echo "------------------------------------"
+docker-compose up -d
+
+waitForDCService nodeA
+waitForDCService nodeB
+
+# Wait for Nuts Network nodes to build connections
+sleep 5
+
+echo "------------------------------------"
+echo "Asserting..."
+echo "------------------------------------"
+
+didNodeA=$(findNodeDID "node-A/nuts.yaml")
+printf "NodeDID for node-a: %s\n" "$didNodeA"
+
+didNodeB=$(findNodeDID "node-B/nuts.yaml")
+printf "NodeDID for node-b: %s\n" "$didNodeB"
+
+createAuthCredential "http://localhost:11323" "$didNodeA" "$didNodeB"
+createAuthCredential "http://localhost:21323" "$didNodeB" "$didNodeA"
+
+# Wait for transactions to sync
+sleep 5
+
+if [ $(searchAuthCredentials "http://localhost:11323" | jq "length") -ne 2 ]; then
+  echo "failed to find NutsAuthorizationCredentials on Node-A"
+  exit 1
+fi
+
+if [ $(searchAuthCredentials "http://localhost:21323" | jq "length") -ne 2 ]; then
+  echo "failed to find NutsAuthorizationCredentials on Node-A"
+  exit 1
+fi
+
+echo "------------------------------------"
+echo "Stopping Docker containers..."
+echo "------------------------------------"
+docker-compose stop


### PR DESCRIPTION
E2E test for private transactions. Build in two steps:

1. Create DIDs, NutsComm endpoints and add new DIDs to YAML config
2. Create NutsAuthorizationCredentials and assert if they are present on both nodes (thus the syncing works)

Closes: https://github.com/nuts-foundation/nuts-node/issues/713