### PR TITLE
Add basic test with nodes using Redis storage

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -10,6 +10,13 @@ pushd nuts-network
 popd
 
 echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+echo "!! Running test suite: Storage      !!"
+echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+pushd storage
+./run-tests.sh
+popd
+
+echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
 echo "!! Running test suite: OAuth flow   !!"
 echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
 pushd oauth-flow

--- a/storage/README.md
+++ b/storage/README.md
@@ -1,0 +1,1 @@
+This test suite tests specific storage configurations for the Nuts Node.

--- a/storage/redis/docker-compose.yml
+++ b/storage/redis/docker-compose.yml
@@ -1,0 +1,29 @@
+version: "3.7"
+services:
+  nodeA:
+    image: reinkrul/nuts-node:latest
+    environment:
+      NUTS_CONFIGFILE: /opt/nuts/nuts.yaml
+    ports:
+      - "11323:1323"
+    volumes:
+      - "./node-A/nuts.yaml:/opt/nuts/nuts.yaml:ro"
+      - "../../tls-certs/nodeA-certificate.pem:/opt/nuts/certificate-and-key.pem:ro"
+      - "../../tls-certs/truststore.pem:/opt/nuts/truststore.pem:ro"
+    healthcheck:
+      interval: 1s # Make test run quicker by checking health status more often
+  nodeB:
+    image: reinkrul/nuts-node:latest
+    environment:
+      NUTS_CONFIGFILE: /opt/nuts/nuts.yaml
+    ports:
+      - "21323:1323"
+    volumes:
+      - "./node-B/nuts.yaml:/opt/nuts/nuts.yaml:ro"
+      - "../../tls-certs/nodeB-certificate.pem:/opt/nuts/certificate-and-key.pem:ro"
+      - "../../tls-certs/truststore.pem:/opt/nuts/truststore.pem:ro"
+    healthcheck:
+      interval: 1s # Make test run quicker by checking health status more often
+  redis:
+    image: redis:7
+    command: redis-server

--- a/storage/redis/docker-compose.yml
+++ b/storage/redis/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 services:
   nodeA:
-    image: reinkrul/nuts-node:latest
+    image: nutsfoundation/nuts-node:master
     environment:
       NUTS_CONFIGFILE: /opt/nuts/nuts.yaml
     ports:
@@ -13,7 +13,7 @@ services:
     healthcheck:
       interval: 1s # Make test run quicker by checking health status more often
   nodeB:
-    image: reinkrul/nuts-node:latest
+    image: nutsfoundation/nuts-node:master
     environment:
       NUTS_CONFIGFILE: /opt/nuts/nuts.yaml
     ports:

--- a/storage/redis/node-A/nuts.yaml
+++ b/storage/redis/node-A/nuts.yaml
@@ -1,0 +1,20 @@
+verbosity: debug
+http:
+  default:
+    address: :1323
+auth:
+  publicurl: http://node-A
+  contractvalidators:
+    - dummy
+  irma:
+    autoupdateschemas: false
+network:
+  publicaddr: nodeA:5555
+  grpcaddr:	:5555
+  truststorefile: /opt/nuts/truststore.pem
+  certfile: /opt/nuts/certificate-and-key.pem
+  certkeyfile: /opt/nuts/certificate-and-key.pem
+storage:
+  redis:
+    address: redis:6379
+    database: nodeA

--- a/storage/redis/node-B/nuts.yaml
+++ b/storage/redis/node-B/nuts.yaml
@@ -1,0 +1,21 @@
+verbosity: debug
+http:
+  default:
+    address: :1323
+auth:
+  publicurl: http://node-B
+  contractvalidators:
+    - dummy
+  irma:
+    autoupdateschemas: false
+network:
+  bootstrapnodes: nodeA:5555
+  publicaddr: nodeB:5555
+  grpcaddr:	:5555
+  truststorefile: /opt/nuts/truststore.pem
+  certfile: /opt/nuts/certificate-and-key.pem
+  certkeyfile: /opt/nuts/certificate-and-key.pem
+storage:
+  redis:
+    address: redis:6379
+    database: nodeB

--- a/storage/redis/run-test.sh
+++ b/storage/redis/run-test.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+source ../../util.sh
+
+echo "------------------------------------"
+echo "Cleaning up running Docker containers and volumes, and key material..."
+echo "------------------------------------"
+docker-compose down
+docker-compose rm -f -v
+
+echo "------------------------------------"
+echo "Starting Docker containers..."
+echo "------------------------------------"
+docker-compose up -d
+waitForDCService nodeA
+waitForDCService nodeB
+
+echo "------------------------------------"
+echo "Creating root"
+echo "------------------------------------"
+curl -s -X POST http://localhost:11323/internal/vdr/v1/did >/dev/null
+waitForTXCount "NodeA" "http://localhost:11323/status/diagnostics" 1 10
+waitForTXCount "NodeB" "http://localhost:21323/status/diagnostics" 1 10
+
+# create 20 new DID documents on each node
+echo "------------------------------------"
+echo "Creating transactions"
+echo "------------------------------------"
+for _ in {1..20}
+do
+   curl -s -X POST http://localhost:11323/internal/vdr/v1/did >/dev/null
+   curl -s -X POST http://localhost:21323/internal/vdr/v1/did >/dev/null
+done
+
+echo "------------------------------------"
+echo "Performing assertions..."
+echo "------------------------------------"
+waitForTXCount "NodeA" "http://localhost:11323/status/diagnostics" 41 10
+waitForTXCount "NodeB" "http://localhost:21323/status/diagnostics" 41 10
+
+echo "------------------------------------"
+echo "Stopping Docker containers..."
+echo "------------------------------------"
+docker-compose stop

--- a/storage/redis/run-test.sh
+++ b/storage/redis/run-test.sh
@@ -32,9 +32,22 @@ do
    curl -s -X POST http://localhost:21323/internal/vdr/v1/did >/dev/null
 done
 
+echo "----------------------------------------"
+echo "Performing assertions before restart..."
+echo "----------------------------------------"
+waitForTXCount "NodeA" "http://localhost:11323/status/diagnostics" 41 10
+waitForTXCount "NodeB" "http://localhost:21323/status/diagnostics" 41 10
+
 echo "------------------------------------"
-echo "Performing assertions..."
+echo "Restarting Docker containers..."
 echo "------------------------------------"
+docker-compose restart nodeA nodeB
+waitForDCService nodeA
+waitForDCService nodeB
+
+echo "----------------------------------------"
+echo "Performing assertions after restart..."
+echo "----------------------------------------"
 waitForTXCount "NodeA" "http://localhost:11323/status/diagnostics" 41 10
 waitForTXCount "NodeB" "http://localhost:21323/status/diagnostics" 41 10
 

--- a/storage/run-tests.sh
+++ b/storage/run-tests.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -e # make script fail if any of the tests returns a non-zero exit code
+
+echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+echo "!! Running test: Redis            !!"
+echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+pushd redis
+./run-test.sh
+popd


### PR DESCRIPTION
If this PR contains a new test, make sure
- [x] it contains a `docker-compose.yml` file using the `nutsfoundation/nuts-node:master` image (for images that should be replaced during automated testing),
- [x] it can be run with a `run-test.sh` script that is called from _all_ appropriate `run-tests.sh` scripts