### PR TITLE
Fix SSL offloading test

### DIFF
--- a/nuts-network/ssl-offloading/docker-compose.yml
+++ b/nuts-network/ssl-offloading/docker-compose.yml
@@ -8,12 +8,12 @@ services:
       NUTS_CONFIGFILE: /opt/nuts/nuts.yaml
     volumes:
       - "./node-A/nuts.yaml:/opt/nuts/nuts.yaml:ro"
-      - "../../tls-certs/nodeA-backend-certificate.pem:/opt/nuts/certificate-and-key.pem:ro"
       - "../../tls-certs/truststore.pem:/opt/nuts/truststore.pem:ro"
+      - "../../tls-certs/nodeA-certificate.pem:/opt/nuts/certificate-and-key.pem:ro"
     healthcheck:
       interval: 1s # Make test run quicker by checking health status more often
   nodeA:
-    image: nginx:1.18
+    image: nginx:1.23
     volumes:
       - "./node-A/nginx.conf:/etc/nginx/nginx.conf:ro"
       - "../../tls-certs/nodeA-certificate.pem:/etc/nginx/ssl/server.pem:ro"

--- a/nuts-network/ssl-offloading/node-A/nginx.conf
+++ b/nuts-network/ssl-offloading/node-A/nginx.conf
@@ -41,8 +41,10 @@ http {
       ssl_client_certificate    /etc/nginx/ssl/truststore.pem;
       ssl_verify_client         on;
       ssl_verify_depth          1;
+
       location / {
         grpc_pass grpc://nodeA-backend;
+        grpc_set_header X-SSL-CERT $ssl_client_escaped_cert;
       }
     }
 }

--- a/nuts-network/ssl-offloading/node-A/nuts.yaml
+++ b/nuts-network/ssl-offloading/node-A/nuts.yaml
@@ -4,7 +4,6 @@ http:
   default:
     address: :1323
 auth:
-  publicurl: http://node-A
   contractvalidators:
     - dummy
   irma:
@@ -12,7 +11,11 @@ auth:
 network:
   publicaddr: nodeA:5555
   grpcaddr:	:5555
-  # Because the proxy is offloading TLS for this node, enableTLS=false and trustStoreFile is not configured:
-  enabletls: false
+  truststorefile: /opt/nuts/truststore.pem
+  certfile: /opt/nuts/certificate-and-key.pem
+  certkeyfile: /opt/nuts/certificate-and-key.pem
+  tls:
+    offload: incoming
+    certheader: X-SSL-CERT
   v2:
     gossipinterval: 250

--- a/nuts-network/ssl-offloading/node-B/nuts.yaml
+++ b/nuts-network/ssl-offloading/node-B/nuts.yaml
@@ -4,7 +4,6 @@ http:
   default:
     address: :1323
 auth:
-  publicurl: http://node-B
   contractvalidators:
     - dummy
   irma:
@@ -15,6 +14,6 @@ network:
   grpcaddr:	:5555
   truststorefile: /opt/nuts/truststore.pem
   certfile: /opt/nuts/certificate-and-key.pem
-  certfeyFile: /opt/nuts/certificate-and-key.pem
+  certkeyfile: /opt/nuts/certificate-and-key.pem
   v2:
     gossipinterval: 250

--- a/nuts-network/ssl-offloading/run-test.sh
+++ b/nuts-network/ssl-offloading/run-test.sh
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
 source ../../util.sh
 
-echo "TEST DISABLED: CURRENTLY NOT SUPPORTED"
-exit 0
-
 echo "------------------------------------"
 echo "Cleaning up running Docker containers and volumes, and key material..."
 echo "------------------------------------"
@@ -18,7 +15,7 @@ waitForDCService nodeA-backend
 waitForDCService nodeB
 
 echo "------------------------------------"
-echo "Performing assertions..."
+echo "Performing assertions (nodes are connected)..."
 echo "------------------------------------"
 # Wait for Nuts Network nodes to build connections
 sleep 5
@@ -41,6 +38,18 @@ else
   echo $RESPONSE
   exitWithDockerLogs 1
 fi
+
+
+echo "------------------------------------"
+echo "Creating transaction"
+echo "------------------------------------"
+curl -s -X POST http://localhost:11323/internal/vdr/v1/did >/dev/null
+echo "------------------------------------"
+echo "Performing assertions (number of transactions)..."
+echo "------------------------------------"
+
+waitForTXCount "NodeA" "http://localhost:11323/status/diagnostics" 1 10
+waitForTXCount "NodeB" "http://localhost:21323/status/diagnostics" 1 10
 
 echo "------------------------------------"
 echo "Stopping Docker containers..."


### PR DESCRIPTION
If this PR contains a new test, make sure
- [x] it contains a `docker-compose.yml` file using the `nutsfoundation/nuts-node:master` image (for images that should be replaced during automated testing),
- [x] it can be run with a `run-test.sh` script that is called from _all_ appropriate `run-tests.sh` scripts