### PR TITLE
prepare.sh MacOS support

### DIFF
--- a/nuts-network/private-transactions/prepare.sh
+++ b/nuts-network/private-transactions/prepare.sh
@@ -27,7 +27,12 @@ echo "------------------------------------"
 docker-compose down
 docker-compose rm -f -v
 rm -rf ./node-*/data
-sed -i '/nodedid: did:nuts:/d' ./node-*/nuts.yaml  # OS X sed fails on this, see https://stackoverflow.com/questions/19456518
+if [[ $OSTYPE == 'darwin'* ]]; then
+  # sed works different on MacOS; see https://stackoverflow.com/questions/19456518
+  sed -i '' -e '/nodedid: did:nuts:/d' ./node-*/nuts.yaml
+else
+  sed -i '/nodedid: did:nuts:/d' ./node-*/nuts.yaml
+fi
 
 echo "------------------------------------"
 echo "Starting Docker containers..."


### PR DESCRIPTION
If this PR contains a new test, make sure
- [x] it contains a `docker-compose.yml` file using the `nutsfoundation/nuts-node:master` image (for images that should be replaced during automated testing),
- [x] it can be run with a `run-test.sh` script that is called from _all_ appropriate `run-tests.sh` scripts