### PR TITLE
Fix file permission issues when running on GitHub Actions

### DIFF
--- a/storage/backup-restore/run-test.sh
+++ b/storage/backup-restore/run-test.sh
@@ -37,6 +37,8 @@ sleep 1 # BBolt backup is made every second
 echo "Making backups and removing node data"
 docker compose stop
 # Copy files not in BBolt DB, so they can be restored. Then empty data dir.
+fixPermissions ./node-data
+fixPermissions ./node-backup
 cp ./node-data/vcr/trusted_issuers.yaml ./node-backup/vcr/
 cp -r ./node-data/crypto ./node-backup
 rm -rf ./node-data/*
@@ -50,6 +52,8 @@ assertDiagnostic "http://localhost:11323" "credential_count: 0"
 # Restore data and rebuild
 echo "Restoring node data"
 docker compose stop
+fixPermissions ./node-data
+fixPermissions ./node-backup
 rm -rf ./node-data/*
 cp -r ./node-backup/* ./node-data/
 BACKUP_INTERVAL=0 docker compose up -d

--- a/util.sh
+++ b/util.sh
@@ -137,3 +137,8 @@ function readCredential() {
 function revokeCredential() {
   curl -s -X DELETE "$1/internal/vcr/v2/issuer/vc/${2//#/%23}"
 }
+
+# fixPermissions changes the user/group of the given directory to the current user/group.
+function fixPermissions() {
+  chown -R $(id -u):$(id -g) $1
+}


### PR DESCRIPTION
If this PR contains a new test, make sure
- [x] it contains a `docker-compose.yml` file using the `nutsfoundation/nuts-node:master` image (for images that should be replaced during automated testing),
- [x] it can be run with a `run-test.sh` script that is called from _all_ appropriate `run-tests.sh` scripts