### PR TITLE
Update config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ This repository contains end-to-end tests for the [nuts-node](https://github.com
 To tun the tests you need the following tools:
 
 - Docker
-- docker-compose
 - [jq](https://stedolan.github.io/jq/) for JSON operations
 
 ## On your machine

--- a/nuts-network/direct-wan/node-A/nuts.yaml
+++ b/nuts-network/direct-wan/node-A/nuts.yaml
@@ -12,6 +12,7 @@ auth:
 network:
   publicaddr: nodeA:5555
   grpcaddr:	:5555
+tls:
   truststorefile: /opt/nuts/truststore.pem
   certfile: /opt/nuts/certificate-and-key.pem
   certkeyfile: /opt/nuts/certificate-and-key.pem

--- a/nuts-network/direct-wan/node-B/nuts.yaml
+++ b/nuts-network/direct-wan/node-B/nuts.yaml
@@ -13,6 +13,7 @@ network:
   bootstrapnodes: nodeA:5555
   publicaddr: nodeB:5555
   grpcaddr:	:5555
+tls:
   truststorefile: /opt/nuts/truststore.pem
   certfile: /opt/nuts/certificate-and-key.pem
   certkeyfile: /opt/nuts/certificate-and-key.pem

--- a/nuts-network/direct-wan/run-test.sh
+++ b/nuts-network/direct-wan/run-test.sh
@@ -5,13 +5,13 @@ source ../../util.sh
 echo "------------------------------------"
 echo "Cleaning up running Docker containers and volumes, and key material..."
 echo "------------------------------------"
-docker-compose down
-docker-compose rm -f -v
+docker compose down
+docker compose rm -f -v
 
 echo "------------------------------------"
 echo "Starting Docker containers..."
 echo "------------------------------------"
-docker-compose up -d
+docker compose up -d
 waitForDCService nodeA
 waitForDCService nodeB
 
@@ -27,4 +27,4 @@ assertDiagnostic "http://localhost:21323" "connected_peers_count: 1"
 echo "------------------------------------"
 echo "Stopping Docker containers..."
 echo "------------------------------------"
-docker-compose stop
+docker compose stop

--- a/nuts-network/gossip-overflow/run-test.sh
+++ b/nuts-network/gossip-overflow/run-test.sh
@@ -5,13 +5,13 @@ source ../../util.sh
 echo "------------------------------------"
 echo "Cleaning up running Docker containers and volumes, and key material..."
 echo "------------------------------------"
-docker-compose down
-docker-compose rm -f -v
+docker compose down
+docker compose rm -f -v
 
 echo "------------------------------------"
 echo "Starting Docker containers..."
 echo "------------------------------------"
-docker-compose up -d
+docker compose up -d
 waitForDCService nodeA
 waitForDCService nodeB
 
@@ -37,4 +37,4 @@ waitForTXCount "NodeB" "http://localhost:21323/status/diagnostics" 200 20
 echo "------------------------------------"
 echo "Stopping Docker containers..."
 echo "------------------------------------"
-docker-compose stop
+docker compose stop

--- a/nuts-network/gossip/run-test.sh
+++ b/nuts-network/gossip/run-test.sh
@@ -5,13 +5,13 @@ source ../../util.sh
 echo "------------------------------------"
 echo "Cleaning up running Docker containers and volumes, and key material..."
 echo "------------------------------------"
-docker-compose down
-docker-compose rm -f -v
+docker compose down
+docker compose rm -f -v
 
 echo "------------------------------------"
 echo "Starting Docker containers..."
 echo "------------------------------------"
-docker-compose up -d
+docker compose up -d
 waitForDCService nodeA
 waitForDCService nodeB
 waitForDCService nodeC
@@ -51,4 +51,4 @@ waitForTXCount "NodeD" "http://localhost:41323/status/diagnostics" 81 10
 echo "------------------------------------"
 echo "Stopping Docker containers..."
 echo "------------------------------------"
-docker-compose stop
+docker compose stop

--- a/nuts-network/private-transactions/node-A/nuts.yaml
+++ b/nuts-network/private-transactions/node-A/nuts.yaml
@@ -1,6 +1,7 @@
 verbosity: debug
 internalratelimiter: false
 datadir: /opt/nuts/data
+strictmode: true
 http:
   default:
     address: :1323
@@ -12,11 +13,13 @@ auth:
     autoupdateschemas: false
 vcr:
   overrideissueallpublic: false
-network:
-  publicaddr: nodeA:5555
-  grpcaddr:	:5555
+tls:
   truststorefile: /opt/nuts/truststore.pem
   certfile: /opt/nuts/certificate-and-key.pem
   certkeyfile: /opt/nuts/certificate-and-key.pem
+network:
+  publicaddr: nodeA:5555
+  grpcaddr:	:5555
   v2:
     gossipinterval: 500
+  nodedid: did:nuts:2hNMXVSeUNASPmBYTGckLk7KoBosKVNJE2Ey7Ka61QVZ

--- a/nuts-network/private-transactions/node-B/nuts.yaml
+++ b/nuts-network/private-transactions/node-B/nuts.yaml
@@ -1,6 +1,7 @@
 verbosity: debug
 internalratelimiter: false
 datadir: /opt/nuts/data
+strictmode: true
 http:
   default:
     address: :1323
@@ -12,12 +13,14 @@ auth:
     autoupdateschemas: false
 vcr:
   overrideissueallpublic: false
+tls:
+  truststorefile: /opt/nuts/truststore.pem
+  certfile: /opt/nuts/certificate-and-key.pem
+  certkeyfile: /opt/nuts/certificate-and-key.pem
 network:
   bootstrapnodes: nodeA:5555
   publicaddr: nodeB:5555
   grpcaddr:	:5555
-  truststorefile: /opt/nuts/truststore.pem
-  certfile: /opt/nuts/certificate-and-key.pem
-  certkeyfile: /opt/nuts/certificate-and-key.pem
   v2:
     gossipinterval: 450
+  nodedid: did:nuts:H8VPcV4TGkjFiq1iT8VQXR6e6scS1jRLWNvU8xEAJpSM

--- a/nuts-network/private-transactions/prepare.sh
+++ b/nuts-network/private-transactions/prepare.sh
@@ -8,8 +8,8 @@ echo "------------------------------------"
 echo "Cleaning up running Docker containers and volumes, and key material..."
 echo "------------------------------------"
 
-docker-compose down
-docker-compose rm -f -v
+docker compose down
+docker compose rm -f -v
 rm -rf ./node-*/data
 if [[ $OSTYPE == 'darwin'* ]]; then
   # sed works different on MacOS; see https://stackoverflow.com/questions/19456518
@@ -22,7 +22,7 @@ echo "------------------------------------"
 echo "Starting Docker containers..."
 echo "------------------------------------"
 
-docker-compose up -d
+docker compose up -d
 
 waitForDCService nodeA
 waitForDCService nodeB
@@ -49,4 +49,4 @@ sleep 5
 echo "  nodedid: $didNodeA" >> node-A/nuts.yaml
 echo "  nodedid: $didNodeB" >> node-B/nuts.yaml
 
-docker-compose stop
+docker compose stop

--- a/nuts-network/private-transactions/run-test.sh
+++ b/nuts-network/private-transactions/run-test.sh
@@ -26,7 +26,7 @@ function searchAuthCredentials() {
 echo "------------------------------------"
 echo "Starting Docker containers..."
 echo "------------------------------------"
-docker-compose up -d
+docker compose up -d
 
 waitForDCService nodeA
 waitForDCService nodeB
@@ -84,4 +84,4 @@ fi
 echo "------------------------------------"
 echo "Stopping Docker containers..."
 echo "------------------------------------"
-docker-compose down
+docker compose stop

--- a/nuts-network/ssl-offloading/haproxy/node-A/nuts.yaml
+++ b/nuts-network/ssl-offloading/haproxy/node-A/nuts.yaml
@@ -6,13 +6,13 @@ auth:
   irma:
     autoupdateschemas: false
 tls:
+  truststorefile: /opt/nuts/truststore.pem
+  certfile: /opt/nuts/certificate-and-key.pem
+  certkeyfile: /opt/nuts/certificate-and-key.pem
   offload: incoming
   certheader: X-SSL-CERT
 network:
   publicaddr: nodeA:5555
   grpcaddr:	:5555
-  truststorefile: /opt/nuts/truststore.pem
-  certfile: /opt/nuts/certificate-and-key.pem
-  certkeyfile: /opt/nuts/certificate-and-key.pem
   v2:
     gossipinterval: 250

--- a/nuts-network/ssl-offloading/haproxy/node-B/nuts.yaml
+++ b/nuts-network/ssl-offloading/haproxy/node-B/nuts.yaml
@@ -6,14 +6,14 @@ auth:
   irma:
     autoupdateschemas: false
 tls:
+  truststorefile: /opt/nuts/truststore.pem
+  certfile: /opt/nuts/certificate-and-key.pem
+  certkeyfile: /opt/nuts/certificate-and-key.pem
   offload: incoming
   certheader: X-SSL-CERT
 network:
   bootstrapnodes: nodeA:443
   publicaddr: nodeB:5555
   grpcaddr:	:5555
-  truststorefile: /opt/nuts/truststore.pem
-  certfile: /opt/nuts/certificate-and-key.pem
-  certkeyfile: /opt/nuts/certificate-and-key.pem
   v2:
     gossipinterval: 250

--- a/nuts-network/ssl-offloading/haproxy/run-test.sh
+++ b/nuts-network/ssl-offloading/haproxy/run-test.sh
@@ -4,13 +4,13 @@ source ../../../util.sh
 echo "------------------------------------"
 echo "Cleaning up running Docker containers and volumes, and key material..."
 echo "------------------------------------"
-docker-compose down
-docker-compose rm -f -v
+docker compose down
+docker compose rm -f -v
 
 echo "------------------------------------"
 echo "Starting Docker containers..."
 echo "------------------------------------"
-docker-compose up -d
+docker compose up -d
 waitForDCService nodeA-backend
 waitForDCService nodeB
 
@@ -37,4 +37,4 @@ waitForTXCount "NodeB" "http://localhost:21323/status/diagnostics" 1 10
 echo "------------------------------------"
 echo "Stopping Docker containers..."
 echo "------------------------------------"
-docker-compose stop
+docker compose stop

--- a/nuts-network/ssl-offloading/nginx/node-A/nuts.yaml
+++ b/nuts-network/ssl-offloading/nginx/node-A/nuts.yaml
@@ -6,13 +6,13 @@ auth:
   irma:
     autoupdateschemas: false
 tls:
+  truststorefile: /opt/nuts/truststore.pem
+  certfile: /opt/nuts/certificate-and-key.pem
+  certkeyfile: /opt/nuts/certificate-and-key.pem
   offload: incoming
   certheader: X-SSL-CERT
 network:
   publicaddr: nodeA:5555
   grpcaddr:	:5555
-  truststorefile: /opt/nuts/truststore.pem
-  certfile: /opt/nuts/certificate-and-key.pem
-  certkeyfile: /opt/nuts/certificate-and-key.pem
   v2:
     gossipinterval: 250

--- a/nuts-network/ssl-offloading/nginx/node-B/nuts.yaml
+++ b/nuts-network/ssl-offloading/nginx/node-B/nuts.yaml
@@ -6,14 +6,14 @@ auth:
   irma:
     autoupdateschemas: false
 tls:
+  truststorefile: /opt/nuts/truststore.pem
+  certfile: /opt/nuts/certificate-and-key.pem
+  certkeyfile: /opt/nuts/certificate-and-key.pem
   offload: incoming
   certheader: X-SSL-CERT
 network:
   bootstrapnodes: nodeA:443
   publicaddr: nodeB:5555
   grpcaddr:	:5555
-  truststorefile: /opt/nuts/truststore.pem
-  certfile: /opt/nuts/certificate-and-key.pem
-  certkeyfile: /opt/nuts/certificate-and-key.pem
   v2:
     gossipinterval: 250

--- a/nuts-network/ssl-offloading/nginx/run-test.sh
+++ b/nuts-network/ssl-offloading/nginx/run-test.sh
@@ -4,13 +4,13 @@ source ../../../util.sh
 echo "------------------------------------"
 echo "Cleaning up running Docker containers and volumes, and key material..."
 echo "------------------------------------"
-docker-compose down
-docker-compose rm -f -v
+docker compose down
+docker compose rm -f -v
 
 echo "------------------------------------"
 echo "Starting Docker containers..."
 echo "------------------------------------"
-docker-compose up -d
+docker compose up -d
 waitForDCService nodeA-backend
 waitForDCService nodeB
 
@@ -37,4 +37,4 @@ waitForTXCount "NodeB" "http://localhost:21323/status/diagnostics" 1 10
 echo "------------------------------------"
 echo "Stopping Docker containers..."
 echo "------------------------------------"
-docker-compose stop
+docker compose stop

--- a/nuts-network/ssl-pass-through/node-A/nuts.yaml
+++ b/nuts-network/ssl-pass-through/node-A/nuts.yaml
@@ -7,8 +7,9 @@ auth:
 network:
   publicaddr: nodeA:5555
   grpcaddr:	:5555
+  v2:
+    gossipinterval: 250
+tls:
   truststorefile: /opt/nuts/truststore.pem
   certfile: /opt/nuts/certificate-and-key.pem
   certkeyfile: /opt/nuts/certificate-and-key.pem
-  v2:
-    gossipinterval: 250

--- a/nuts-network/ssl-pass-through/node-B/nuts.yaml
+++ b/nuts-network/ssl-pass-through/node-B/nuts.yaml
@@ -8,8 +8,9 @@ network:
   bootstrapnodes: nodeA:5555
   publicaddr: nodeB:5555
   grpcaddr:	:5555
+  v2:
+    gossipinterval: 250
+tls:
   truststorefile: /opt/nuts/truststore.pem
   certfile: /opt/nuts/certificate-and-key.pem
   certkeyfile: /opt/nuts/certificate-and-key.pem
-  v2:
-    gossipinterval: 250

--- a/nuts-network/ssl-pass-through/run-test.sh
+++ b/nuts-network/ssl-pass-through/run-test.sh
@@ -4,13 +4,13 @@ source ../../util.sh
 echo "------------------------------------"
 echo "Cleaning up running Docker containers and volumes, and key material..."
 echo "------------------------------------"
-docker-compose down
-docker-compose rm -f -v
+docker compose down
+docker compose rm -f -v
 
 echo "------------------------------------"
 echo "Starting Docker containers..."
 echo "------------------------------------"
-docker-compose up -d
+docker compose up -d
 waitForDCService nodeA-backend
 waitForDCService nodeB
 
@@ -36,4 +36,4 @@ waitForTXCount "NodeB" "http://localhost:21323/status/diagnostics" 1 10
 echo "------------------------------------"
 echo "Stopping Docker containers..."
 echo "------------------------------------"
-docker-compose stop
+docker compose stop

--- a/oauth-flow/node-A/nuts.yaml
+++ b/oauth-flow/node-A/nuts.yaml
@@ -10,9 +10,10 @@ auth:
     - dummy
   irma:
     autoupdateschemas: false
-network:
+tls:
   truststorefile: /opt/nuts/truststore.pem
   certfile: /opt/nuts/certificate-and-key.pem
   certkeyfile: /opt/nuts/certificate-and-key.pem
+network:
   v2:
     gossipinterval: 500

--- a/oauth-flow/node-B/nuts.yaml
+++ b/oauth-flow/node-B/nuts.yaml
@@ -11,10 +11,11 @@ auth:
     - dummy
   irma:
     autoupdateschemas: false
-network:
+tls:
   truststorefile: /opt/nuts/truststore.pem
   certfile: /opt/nuts/certificate-and-key.pem
   certkeyfile: /opt/nuts/certificate-and-key.pem
+network:
   bootstrapnodes: nodeA-backend:5555
   v2:
     gossipinterval: 400

--- a/storage/backup-restore/node-A/nuts.yaml
+++ b/storage/backup-restore/node-A/nuts.yaml
@@ -7,6 +7,7 @@ auth:
     autoupdateschemas: false
 network:
   grpcaddr:	:5555
+tls:
   truststorefile: /opt/nuts/truststore.pem
   certfile: /opt/nuts/certificate-and-key.pem
   certkeyfile: /opt/nuts/certificate-and-key.pem

--- a/storage/backup-restore/run-test.sh
+++ b/storage/backup-restore/run-test.sh
@@ -5,8 +5,8 @@ source ../../util.sh
 echo "------------------------------------"
 echo "Cleaning up running Docker containers and volumes, and key material..."
 echo "------------------------------------"
-docker-compose down
-docker-compose rm -f -v
+docker compose down
+docker compose rm -f -v
 rm -rf ./node-data/*
 rm -rf ./node-backup/*
 mkdir ./node-data ./node-backup ./node-backup/vcr/ # 'data' dirs will be created with root owner by docker if they do not exit. This creates permission issues on CI.
@@ -14,7 +14,7 @@ mkdir ./node-data ./node-backup ./node-backup/vcr/ # 'data' dirs will be created
 echo "------------------------------------"
 echo "Starting Docker containers..."
 echo "------------------------------------"
-docker-compose up -d
+docker compose up -d
 waitForDCService nodeA
 
 echo "------------------------------------"

--- a/storage/redis/node-A/nuts.yaml
+++ b/storage/redis/node-A/nuts.yaml
@@ -12,6 +12,7 @@ auth:
 network:
   publicaddr: nodeA:5555
   grpcaddr:	:5555
+tls:
   truststorefile: /opt/nuts/truststore.pem
   certfile: /opt/nuts/certificate-and-key.pem
   certkeyfile: /opt/nuts/certificate-and-key.pem

--- a/storage/redis/node-B/nuts.yaml
+++ b/storage/redis/node-B/nuts.yaml
@@ -13,6 +13,7 @@ network:
   bootstrapnodes: nodeA:5555
   publicaddr: nodeB:5555
   grpcaddr:	:5555
+tls:
   truststorefile: /opt/nuts/truststore.pem
   certfile: /opt/nuts/certificate-and-key.pem
   certkeyfile: /opt/nuts/certificate-and-key.pem

--- a/storage/redis/run-test.sh
+++ b/storage/redis/run-test.sh
@@ -5,13 +5,13 @@ source ../../util.sh
 echo "------------------------------------"
 echo "Cleaning up running Docker containers and volumes, and key material..."
 echo "------------------------------------"
-docker-compose down
-docker-compose rm -f -v
+docker compose down
+docker compose rm -f -v
 
 echo "------------------------------------"
 echo "Starting Docker containers..."
 echo "------------------------------------"
-docker-compose up -d
+docker compose up -d
 waitForDCService nodeA
 waitForDCService nodeB
 
@@ -41,7 +41,7 @@ waitForTXCount "NodeB" "http://localhost:21323/status/diagnostics" 41 10
 echo "------------------------------------"
 echo "Restarting Docker containers..."
 echo "------------------------------------"
-docker-compose restart nodeA nodeB redis
+docker compose restart nodeA nodeB redis
 waitForDCService nodeA
 waitForDCService nodeB
 
@@ -54,4 +54,4 @@ waitForTXCount "NodeB" "http://localhost:21323/status/diagnostics" 41 10
 echo "------------------------------------"
 echo "Stopping Docker containers..."
 echo "------------------------------------"
-docker-compose stop
+docker compose stop

--- a/util.sh
+++ b/util.sh
@@ -2,11 +2,11 @@
 
 function waitForDCService {
   SERVICE_NAME=$1
-  printf "Waiting for docker-compose service '%s' to become healthy" $SERVICE_NAME
+  printf "Waiting for docker compose service '%s' to become healthy" $SERVICE_NAME
   retry=0
   healthy=0
   while [ $retry -lt 30 ]; do
-    status=$(docker inspect -f {{.State.Health.Status}} $(docker-compose ps -q $SERVICE_NAME))
+    status=$(docker inspect -f {{.State.Health.Status}} $(docker compose ps -q $SERVICE_NAME))
 
     if [[ "$status" == "healthy" ]]; then
       healthy=1
@@ -55,8 +55,8 @@ function waitForTXCount {
 
 function exitWithDockerLogs {
   EXIT_CODE=$1
-  docker-compose logs
-  docker-compose stop
+  docker compose logs
+  docker compose stop
   exit $EXIT_CODE
 }
 


### PR DESCRIPTION
This PR contains 2 changes (separate commits):
- all `nuts.yaml` config files are updated to not use deprecated network flags.
- replace all `docker-compose` with `docker compose`. Both were used, but the first has to be installed separately while the other comes with docker.