### PR TITLE
Add key rotation test

### DIFF
--- a/ops/key-rotation/docker-compose.yml
+++ b/ops/key-rotation/docker-compose.yml
@@ -1,0 +1,26 @@
+version: "3.7"
+services:
+  nodeA:
+    image: "${IMAGE_NODE_A:-nutsfoundation/nuts-node:master}"
+    environment:
+      NUTS_CONFIGFILE: /opt/nuts/nuts.yaml
+    ports:
+      - "11323:1323"
+    volumes:
+      - "./node-A/nuts.yaml:/opt/nuts/nuts.yaml:ro"
+      - "../../tls-certs/nodeA-certificate.pem:/opt/nuts/certificate-and-key.pem:ro"
+      - "../../tls-certs/truststore.pem:/opt/nuts/truststore.pem:ro"
+    healthcheck:
+      interval: 1s # Make test run quicker by checking health status more often
+  nodeB:
+    image: "${IMAGE_NODE_B:-nutsfoundation/nuts-node:master}"
+    environment:
+      NUTS_CONFIGFILE: /opt/nuts/nuts.yaml
+    ports:
+      - "21323:1323"
+    volumes:
+      - "./node-B/nuts.yaml:/opt/nuts/nuts.yaml:ro"
+      - "../../tls-certs/nodeB-certificate.pem:/opt/nuts/certificate-and-key.pem:ro"
+      - "../../tls-certs/truststore.pem:/opt/nuts/truststore.pem:ro"
+    healthcheck:
+      interval: 1s # Make test run quicker by checking health status more often

--- a/ops/key-rotation/node-A/nuts.yaml
+++ b/ops/key-rotation/node-A/nuts.yaml
@@ -1,0 +1,21 @@
+verbosity: debug
+internalratelimiter: false
+http:
+  default:
+    address: :1323
+auth:
+  publicurl: http://node-A
+  contractvalidators:
+    - dummy
+  irma:
+    autoupdateschemas: false
+network:
+  publicaddr: nodeA:5555
+  grpcaddr:	:5555
+  certfile: /opt/nuts/certificate-and-key.pem
+  certkeyfile: /opt/nuts/certificate-and-key.pem
+  truststorefile: /opt/nuts/truststore.pem
+tls:
+  truststorefile: /opt/nuts/truststore.pem
+  certfile: /opt/nuts/certificate-and-key.pem
+  certkeyfile: /opt/nuts/certificate-and-key.pem

--- a/ops/key-rotation/node-B/nuts.yaml
+++ b/ops/key-rotation/node-B/nuts.yaml
@@ -1,0 +1,22 @@
+verbosity: debug
+internalratelimiter: false
+http:
+  default:
+    address: :1323
+auth:
+  publicurl: http://node-B
+  contractvalidators:
+    - dummy
+  irma:
+    autoupdateschemas: false
+network:
+  bootstrapnodes: nodeA:5555
+  publicaddr: nodeB:5555
+  grpcaddr:	:5555
+  certfile: /opt/nuts/certificate-and-key.pem
+  certkeyfile: /opt/nuts/certificate-and-key.pem
+  truststorefile: /opt/nuts/truststore.pem
+tls:
+  truststorefile: /opt/nuts/truststore.pem
+  certfile: /opt/nuts/certificate-and-key.pem
+  certkeyfile: /opt/nuts/certificate-and-key.pem

--- a/ops/key-rotation/run-test.sh
+++ b/ops/key-rotation/run-test.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+
+source ../../util.sh
+
+echo "------------------------------------"
+echo "Cleaning up running Docker containers and volumes, and key material..."
+echo "------------------------------------"
+docker compose down
+docker compose rm -f -v
+
+echo "------------------------------------"
+echo "Starting Docker containers..."
+echo "------------------------------------"
+docker compose up -d
+waitForDCService nodeA
+waitForDCService nodeB
+
+# Test description:
+#  Node A:
+#    1. create DID,
+#    2. add verification method (should be signed with current, old key),
+#    3. remove old key (should be signed with new key),
+#    4. add service (should be signed with new key)
+#  Node B:
+#    5. resolve DID,
+#    6. assert old key is not present in latest version,
+#    7. assert new key is present
+#    8. assert new service is present
+
+echo "------------------------------------"
+echo "Creating DID and performing key rotation..."
+echo "------------------------------------"
+# Register DID
+DIDDOC=$(docker compose exec nodeA nuts vdr create-did)
+DID=$(echo $DIDDOC | jq -r .id)
+FIRST_VM_ID=$(echo $DIDDOC | jq -r ".verificationMethod[0].id")
+echo "DID: ${DID}"
+echo "First Verification Method ID: ${FIRST_VM_ID}"
+
+# Add verification method
+VM=$(docker compose exec nodeA nuts vdr addvm $DID)
+SECOND_VM_ID=$(echo $VM | jq -r ".id")
+echo "New Verification Method ID: ${SECOND_VM_ID}"
+
+# Remove old verification method
+docker compose exec nodeA nuts vdr delvm $DID $FIRST_VM_ID
+
+# Register service
+docker compose exec nodeA nuts didman svc add $DID "MotD", "Hello, World!"
+
+echo "------------------------------------"
+echo "Assert DID document on other node..."
+echo "------------------------------------"
+# Wait for Nuts Network nodes to sync
+sleep 2
+
+DIDDOC_RESOLVED=$(docker compose exec nodeB nuts vdr resolve "${DID}")
+
+if [[ "${DIDDOC_RESOLVED}" != *"MotD"* ]]; then
+  echo "failed to find last DID document version from node A"
+  exitWithDockerLogs 1
+fi
+echo OK: Found last DID document version
+
+if [[ "${DIDDOC_RESOLVED}" != *"${SECOND_VM_ID}"* ]]; then
+  echo "failed to find new key on DID document from node A"
+  exitWithDockerLogs 1
+fi
+echo OK: Found new key on DID document
+
+if [[ "${DIDDOC_RESOLVED}" == *"${FIRST_VM_ID}"* ]]; then
+  echo "failed: found find old key on DID document from node A, which should have been removed"
+  exitWithDockerLogs 1
+fi
+echo OK: Old key not present any more on DID document
+
+echo "------------------------------------"
+echo "Stopping Docker containers..."
+echo "------------------------------------"
+docker compose stop

--- a/ops/run-tests.sh
+++ b/ops/run-tests.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -e # make script fail if any of the tests returns a non-zero exit code
+
+echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+echo "!! Running test: Key Rotation     !!"
+echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+pushd key-rotation
+./run-test.sh
+popd

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -22,3 +22,10 @@ echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
 pushd oauth-flow
 ./run-tests.sh
 popd
+
+echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+echo "!! Running test suite: Sysadmin Operations !!"
+echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+pushd ops
+./run-tests.sh
+popd


### PR DESCRIPTION
If this PR contains a new test, make sure
- [x] it contains a `docker-compose.yml` file using the `${IMAGE_NODE_A:-nutsfoundation/nuts-node:master}` (and `B` for the second node) image. 
  This only applied to images that should be replaced during automated testing),
- [x] it can be run with a `run-test.sh` script that is called from _all_ appropriate `run-tests.sh` scripts