### PR TITLE
Test for crypto storage in Vault

### DIFF
--- a/storage/run-tests.sh
+++ b/storage/run-tests.sh
@@ -15,3 +15,10 @@ echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
 pushd backup-restore
 ./run-test.sh
 popd
+
+echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+echo "!! Running test: Vault crypto storage !!"
+echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+pushd vault
+./run-test.sh
+popd

--- a/storage/vault/docker-compose.yml
+++ b/storage/vault/docker-compose.yml
@@ -1,0 +1,25 @@
+version: "3.7"
+services:
+  node:
+    image: "${IMAGE_NODE_A:-nutsfoundation/nuts-node:master}"
+    environment:
+      NUTS_CONFIGFILE: /opt/nuts/nuts.yaml
+    ports:
+      - "11323:1323"
+    volumes:
+      - "./nuts.yaml:/opt/nuts/nuts.yaml:ro"
+      - "../../tls-certs/nodeA-certificate.pem:/opt/nuts/certificate-and-key.pem:ro"
+      - "../../tls-certs/truststore.pem:/opt/nuts/truststore.pem:ro"
+    healthcheck:
+      interval: 1s # Make test run quicker by checking health status more often
+  vault-adapter:
+    image: nutsfoundation/hashicorp-vault-proxy:latest
+    environment:
+      VAULT_ADDR: http://vault:8200
+      VAULT_TOKEN: root
+  vault:
+    image: vault
+    cap_add:
+      - IPC_LOCK
+    environment:
+      VAULT_DEV_ROOT_TOKEN_ID: root

--- a/storage/vault/docker-compose.yml
+++ b/storage/vault/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     healthcheck:
       interval: 1s # Make test run quicker by checking health status more often
   vault-adapter:
-    image: nutsfoundation/hashicorp-vault-proxy:latest
+    image: nutsfoundation/hashicorp-vault-proxy:main
     environment:
       VAULT_ADDR: http://vault:8200
       VAULT_TOKEN: root

--- a/storage/vault/nuts.yaml
+++ b/storage/vault/nuts.yaml
@@ -1,0 +1,23 @@
+verbosity: debug
+internalratelimiter: false
+http:
+  default:
+    address: :1323
+auth:
+  publicurl: http://node-A
+  contractvalidators:
+    - dummy
+  irma:
+    autoupdateschemas: false
+crypto:
+  storage: fs
+network:
+  publicaddr: nodeA:5555
+  grpcaddr:	:5555
+  certfile: /opt/nuts/certificate-and-key.pem
+  certkeyfile: /opt/nuts/certificate-and-key.pem
+  truststorefile: /opt/nuts/truststore.pem
+tls:
+  truststorefile: /opt/nuts/truststore.pem
+  certfile: /opt/nuts/certificate-and-key.pem
+  certkeyfile: /opt/nuts/certificate-and-key.pem

--- a/storage/vault/nuts.yaml
+++ b/storage/vault/nuts.yaml
@@ -10,7 +10,9 @@ auth:
   irma:
     autoupdateschemas: false
 crypto:
-  storage: fs
+  storage: external
+  external:
+    url: http://vault-adapter:8210
 network:
   publicaddr: nodeA:5555
   grpcaddr:	:5555

--- a/storage/vault/run-test.sh
+++ b/storage/vault/run-test.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+source ../../util.sh
+
+echo "------------------------------------"
+echo "Cleaning up running Docker containers and volumes, and key material..."
+echo "------------------------------------"
+docker compose down
+docker compose rm -f -v
+
+echo "------------------------------------"
+echo "Setting up Vault..."
+echo "------------------------------------"
+docker compose up vault --wait
+docker compose exec -e VAULT_TOKEN=root vault vault secrets enable -version=1 -address=http://localhost:8200 kv
+
+echo "------------------------------------"
+echo "Starting Docker containers..."
+echo "------------------------------------"
+docker compose up --wait
+
+echo "------------------------------------"
+echo "Create and update 2 DID documents..."
+echo "------------------------------------"
+DIDDOC_1=$(docker compose exec node nuts vdr create-did)
+DID_1=$(echo $DIDDOC_1 | jq -r .id)
+docker compose exec node nuts didman svc add "${DID_1}" testEndpoint "http://example.com"
+DIDDOC_2=$(docker compose exec node nuts vdr create-did)
+DID_2=$(echo $DIDDOC_2 | jq -r .id)
+docker compose exec node nuts didman svc add "${DID_2}" testEndpoint "http://example.com"
+waitForTXCount "Node" "http://localhost:11323/status/diagnostics" 4 10
+
+echo "------------------------------------"
+echo "Restarting services, use key again..."
+echo "------------------------------------"
+docker compose restart --wait
+docker compose exec node nuts didman svc add "${DID_1}" testEndpoint2 "http://example.com"
+docker compose exec node nuts didman svc add "${DID_2}" testEndpoint2 "http://example.com"
+
+waitForTXCount "Node" "http://localhost:11323/status/diagnostics" 6 10
+
+echo "------------------------------------"
+echo "Stopping Docker containers..."
+echo "------------------------------------"
+docker compose stop

--- a/storage/vault/run-test.sh
+++ b/storage/vault/run-test.sh
@@ -11,7 +11,7 @@ docker compose rm -f -v
 echo "------------------------------------"
 echo "Setting up Vault..."
 echo "------------------------------------"
-docker compose up vault --wait
+docker compose up --wait vault
 docker compose exec -e VAULT_TOKEN=root vault vault secrets enable -version=1 -address=http://localhost:8200 kv
 
 echo "------------------------------------"
@@ -29,15 +29,6 @@ DIDDOC_2=$(docker compose exec node nuts vdr create-did)
 DID_2=$(echo $DIDDOC_2 | jq -r .id)
 docker compose exec node nuts didman svc add "${DID_2}" testEndpoint "http://example.com"
 waitForTXCount "Node" "http://localhost:11323/status/diagnostics" 4 10
-
-echo "------------------------------------"
-echo "Restarting services, use key again..."
-echo "------------------------------------"
-docker compose restart --wait
-docker compose exec node nuts didman svc add "${DID_1}" testEndpoint2 "http://example.com"
-docker compose exec node nuts didman svc add "${DID_2}" testEndpoint2 "http://example.com"
-
-waitForTXCount "Node" "http://localhost:11323/status/diagnostics" 6 10
 
 echo "------------------------------------"
 echo "Stopping Docker containers..."


### PR DESCRIPTION
If this PR contains a new test, make sure
- [x] it contains a `docker-compose.yml` file using the `${IMAGE_NODE_A:-nutsfoundation/nuts-node:master}` (and `B` for the second node) image. 
  This only applied to images that should be replaced during automated testing),
- [x] it can be run with a `run-test.sh` script that is called from _all_ appropriate `run-tests.sh` scripts