### PR TITLE
ssl-pass-through: increase timeout for establishing connection

### DIFF
--- a/nuts-network/ssl-pass-through/run-test.sh
+++ b/nuts-network/ssl-pass-through/run-test.sh
@@ -18,7 +18,7 @@ echo "------------------------------------"
 echo "Performing assertions (nodes are connected)..."
 echo "------------------------------------"
 # Wait for Nuts Network nodes to build connections
-sleep 5
+sleep 10
 assertDiagnostic "http://localhost:11323" "connected_peers_count: 1"
 assertDiagnostic "http://localhost:21323" "connected_peers_count: 1"
 


### PR DESCRIPTION
current timeout appears to be insufficient after connection management refactor