### PR TITLE
Test for OpenID4VCI

### DIFF
--- a/openid4vci/README.md
+++ b/openid4vci/README.md
@@ -1,0 +1,3 @@
+This test suite tests the credential issuance over OpenID Connect 4 Verifiable Credentials. It tests the following cases:
+
+1. Issuer initiated: node A issued a credential to node B using a credential offer and pre-authorized code.

--- a/openid4vci/issuer-initiated/docker-compose.yml
+++ b/openid4vci/issuer-initiated/docker-compose.yml
@@ -1,0 +1,28 @@
+version: "3.7"
+services:
+  nodeA:
+    image: "${IMAGE_NODE_A:-nutsfoundation/nuts-node:master}"
+    environment:
+      NUTS_CONFIGFILE: /opt/nuts/nuts.yaml
+    ports:
+      - "11323:1323"
+    volumes:
+      - "./node-A/data:/opt/nuts/data"
+      - "./node-A/nuts.yaml:/opt/nuts/nuts.yaml:ro"
+      - "../../tls-certs/nodeA-certificate.pem:/opt/nuts/certificate-and-key.pem:ro"
+      - "../../tls-certs/truststore.pem:/opt/nuts/truststore.pem:ro"
+    healthcheck:
+      interval: 1s # Make test run quicker by checking health status more often
+  nodeB:
+    image: "${IMAGE_NODE_B:-nutsfoundation/nuts-node:master}"
+    environment:
+      NUTS_CONFIGFILE: /opt/nuts/nuts.yaml
+    ports:
+      - "21323:1323"
+    volumes:
+      - "./node-B/data:/opt/nuts/data"
+      - "./node-B/nuts.yaml:/opt/nuts/nuts.yaml:ro"
+      - "../../tls-certs/nodeB-certificate.pem:/opt/nuts/certificate-and-key.pem:ro"
+      - "../../tls-certs/truststore.pem:/opt/nuts/truststore.pem:ro"
+    healthcheck:
+      interval: 1s # Make test run quicker by checking health status more often

--- a/openid4vci/issuer-initiated/node-A/nuts.yaml
+++ b/openid4vci/issuer-initiated/node-A/nuts.yaml
@@ -1,0 +1,31 @@
+verbosity: debug
+strictmode: true
+internalratelimiter: false
+datadir: /opt/nuts/data
+http:
+  default:
+    address: :1323
+auth:
+  publicurl: http://nodeA:1323
+  contractvalidators:
+    - dummy
+  irma:
+    autoupdateschemas: false
+crypto:
+  storage: fs
+vcr:
+  overrideissueallpublic: false
+  oidc4vci:
+    enabled: true
+tls:
+  truststorefile: /opt/nuts/truststore.pem
+  certfile: /opt/nuts/certificate-and-key.pem
+  certkeyfile: /opt/nuts/certificate-and-key.pem
+network:
+  publicaddr: nodeA:5555
+  grpcaddr:	:5555
+  v2:
+    gossipinterval: 500
+  certfile: /opt/nuts/certificate-and-key.pem
+  certkeyfile: /opt/nuts/certificate-and-key.pem
+  truststorefile: /opt/nuts/truststore.pem

--- a/openid4vci/issuer-initiated/node-A/nuts.yaml
+++ b/openid4vci/issuer-initiated/node-A/nuts.yaml
@@ -17,6 +17,7 @@ vcr:
   overrideissueallpublic: false
   oidc4vci:
     enabled: true
+    url: http://nodeA:1323
 tls:
   truststorefile: /opt/nuts/truststore.pem
   certfile: /opt/nuts/certificate-and-key.pem

--- a/openid4vci/issuer-initiated/node-B/nuts.yaml
+++ b/openid4vci/issuer-initiated/node-B/nuts.yaml
@@ -1,0 +1,32 @@
+verbosity: debug
+strictmode: true
+internalratelimiter: false
+datadir: /opt/nuts/data
+http:
+  default:
+    address: :1323
+auth:
+  publicurl: http://nodeB:1323
+  contractvalidators:
+    - dummy
+  irma:
+    autoupdateschemas: false
+crypto:
+  storage: fs
+vcr:
+  overrideissueallpublic: false
+  oidc4vci:
+    enabled: true
+tls:
+  truststorefile: /opt/nuts/truststore.pem
+  certfile: /opt/nuts/certificate-and-key.pem
+  certkeyfile: /opt/nuts/certificate-and-key.pem
+network:
+  bootstrapnodes: nodeA:5555
+  publicaddr: nodeB:5555
+  grpcaddr:	:5555
+  v2:
+    gossipinterval: 450
+  certfile: /opt/nuts/certificate-and-key.pem
+  certkeyfile: /opt/nuts/certificate-and-key.pem
+  truststorefile: /opt/nuts/truststore.pem

--- a/openid4vci/issuer-initiated/node-B/nuts.yaml
+++ b/openid4vci/issuer-initiated/node-B/nuts.yaml
@@ -17,6 +17,7 @@ vcr:
   overrideissueallpublic: false
   oidc4vci:
     enabled: true
+    url: http://nodeB:1323
 tls:
   truststorefile: /opt/nuts/truststore.pem
   certfile: /opt/nuts/certificate-and-key.pem

--- a/openid4vci/issuer-initiated/run-test.sh
+++ b/openid4vci/issuer-initiated/run-test.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+set -e
+
+source ../../util.sh
+
+echo "------------------------------------"
+echo "Cleaning up running Docker containers and volumes, and key material..."
+echo "------------------------------------"
+docker compose down
+docker compose rm -f -v
+rm -rf ./node-*/data
+mkdir ./node-A/data ./node-B/data  # 'data' dirs will be created with root owner by docker if they do not exit. This creates permission issues on CI.
+
+echo "------------------------------------"
+echo "Starting Docker containers..."
+echo "------------------------------------"
+docker compose up -d
+
+waitForDCService nodeA
+waitForDCService nodeB
+
+echo "------------------------------------"
+echo "Creating NodeDIDs..."
+echo "------------------------------------"
+
+didNodeA=$(setupNode "http://localhost:11323" "nodeA:5555")
+printf "NodeDID for node-a: %s\n" "$didNodeA"
+# TODO: Not yet required, and not trusted by the other node
+# createNutsOrgCredential "http://localhost:11323" "$didNodeA" "$didNodeA"
+
+# Wait for node B to receive the TXs created by node A, indicating the connection is working
+waitForTXCount "NodeB" "http://localhost:21323/status/diagnostics" 2 10
+
+didNodeB=$(setupNode "http://localhost:21323" "nodeB:5555")
+printf "NodeDID for node-b: %s\n" "$didNodeB"
+# TODO: Not yet required, and not trusted by the other node
+# createNutsOrgCredential "http://localhost:21323" "$didNodeB" "$didNodeB"
+registerStringService "http://localhost:21323" "$didNodeB" "oidc4vci-wallet-metadata" "http://nodeB:1323/identity/$didNodeB/.well-known/openid-credential-wallet"
+
+# Wait for node A to receive all TXs created by node B
+waitForTXCount "NodeA" "http://localhost:11323/status/diagnostics" 5 10
+
+echo "------------------------------------"
+echo "Issuing credential..."
+echo "------------------------------------"
+vcNodeA=$(createAuthCredential "http://localhost:11323" "$didNodeA" "$didNodeB")
+printf "VC issued by node A: %s\n" "$vcNodeA"
+
+waitForDiagnostic "nodeA" issued_credentials_count 1
+waitForDiagnostic "nodeB" credential_count 1
+
+# Now the credential should be present on both nodeA and nodeB
+echo $(readCredential "http://localhost:11323" $vcNodeA)
+echo $(readCredential "http://localhost:21323" $vcNodeA)
+
+echo "------------------------------------"
+echo "Stopping Docker containers..."
+echo "------------------------------------"
+docker compose stop

--- a/openid4vci/issuer-initiated/run-test.sh
+++ b/openid4vci/issuer-initiated/run-test.sh
@@ -26,16 +26,12 @@ echo "------------------------------------"
 
 didNodeA=$(setupNode "http://localhost:11323" "nodeA:5555")
 printf "NodeDID for node-a: %s\n" "$didNodeA"
-# TODO: Not yet required, and not trusted by the other node
-# createNutsOrgCredential "http://localhost:11323" "$didNodeA" "$didNodeA"
 
 # Wait for node B to receive the TXs created by node A, indicating the connection is working
 waitForTXCount "NodeB" "http://localhost:21323/status/diagnostics" 2 10
 
 didNodeB=$(setupNode "http://localhost:21323" "nodeB:5555")
 printf "NodeDID for node-b: %s\n" "$didNodeB"
-# TODO: Not yet required, and not trusted by the other node
-# createNutsOrgCredential "http://localhost:21323" "$didNodeB" "$didNodeB"
 registerStringService "http://localhost:21323" "$didNodeB" "oidc4vci-wallet-metadata" "http://nodeB:1323/identity/$didNodeB/.well-known/openid-credential-wallet"
 
 # Wait for node A to receive all TXs created by node B

--- a/openid4vci/run-tests.sh
+++ b/openid4vci/run-tests.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -e # make script fail if any of the tests returns a non-zero exit code
+
+
+echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+echo "!! Running test: Issuer Initiated !!"
+echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+pushd issuer-initiated
+./run-test.sh
+popd

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -23,6 +23,13 @@ pushd oauth-flow
 ./run-tests.sh
 popd
 
+echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+echo "!! Running test suite: OpenID4VCI   !!"
+echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+pushd openid4vci
+./run-tests.sh
+popd
+
 echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
 echo "!! Running test suite: Sysadmin Operations !!"
 echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"

--- a/util.sh
+++ b/util.sh
@@ -53,6 +53,35 @@ function waitForTXCount {
   echo ""
 }
 
+# waitForDCService waits for a Nuts node's diagnostic to display a certain value for a given key
+# Args:    service name, key to check, expected value
+function waitForDiagnostic {
+  SERVICE_NAME=$1
+  KEY=$2
+  VALUE=$3
+  TIMEOUT=10
+  printf "Waiting for service '%s' diagnostic (%s: %s)" $SERVICE_NAME $KEY $VALUE
+  done=false
+  retry=0
+  while [ $retry -lt $TIMEOUT ]; do
+    RESPONSE=$(docker compose exec $SERVICE_NAME nuts status)
+    if echo $RESPONSE | grep -q "${KEY}: ${VALUE}"; then
+      done=true
+      break
+    fi
+
+    printf "."
+    sleep 1
+    retry=$[$retry+1]
+  done
+
+  if [ $done == false ]; then
+    echo "FAILED"
+    exitWithDockerLogs 1
+  fi
+  echo ""
+}
+
 function exitWithDockerLogs {
   EXIT_CODE=$1
   docker compose logs
@@ -125,6 +154,33 @@ function createAuthCredential() {
     },
    "visibility": "private"
   }' "$2" "$3" | curl -s -X POST "$1/internal/vcr/v2/issuer/vc" -H "Content-Type: application/json" --data-binary @- | jq ".id" | sed "s/\"//g"
+}
+
+# createNutsOrgCredential issues a NutsOrganizationCredential
+# Args:    issuing node HTTP address, issuer DID, subject DID
+# Returns: the VC ID
+function createNutsOrgCredential() {
+  printf '{
+    "type": "NutsOrganizationCredential",
+    "issuer": "%s",
+    "credentialSubject": {
+      "id": "%s",
+      "organization": {
+        "name": "Caresoft B.V.",
+        "city": "Caretown"
+      }
+    },
+    "visibility": "public"
+  }' "$2" "$3" | curl -s -X POST "$1/internal/vcr/v2/issuer/vc" -H "Content-Type: application/json" --data-binary @- | jq ".id" | sed "s/\"//g"
+}
+
+# registerStringService registers a service on a DID document, with a string as serviceEndpoint
+# Args:   issuing node HTTP address, DID, service type, service endpoint
+function registerStringService() {
+    printf '{
+      "type": "%s",
+      "endpoint": "%s"
+    }' "$3" "$4" | curl -s -X POST "$1/internal/didman/v1/did/$2/endpoint" -H "Content-Type: application/json" --data-binary @- > /dev/null
 }
 
 # readCredential resolves a VC

--- a/util.sh
+++ b/util.sh
@@ -156,24 +156,6 @@ function createAuthCredential() {
   }' "$2" "$3" | curl -s -X POST "$1/internal/vcr/v2/issuer/vc" -H "Content-Type: application/json" --data-binary @- | jq ".id" | sed "s/\"//g"
 }
 
-# createNutsOrgCredential issues a NutsOrganizationCredential
-# Args:    issuing node HTTP address, issuer DID, subject DID
-# Returns: the VC ID
-function createNutsOrgCredential() {
-  printf '{
-    "type": "NutsOrganizationCredential",
-    "issuer": "%s",
-    "credentialSubject": {
-      "id": "%s",
-      "organization": {
-        "name": "Caresoft B.V.",
-        "city": "Caretown"
-      }
-    },
-    "visibility": "public"
-  }' "$2" "$3" | curl -s -X POST "$1/internal/vcr/v2/issuer/vc" -H "Content-Type: application/json" --data-binary @- | jq ".id" | sed "s/\"//g"
-}
-
 # registerStringService registers a service on a DID document, with a string as serviceEndpoint
 # Args:   issuing node HTTP address, DID, service type, service endpoint
 function registerStringService() {


### PR DESCRIPTION
If this PR contains a new test, make sure
- [x] it contains a `docker-compose.yml` file using the `${IMAGE_NODE_A:-nutsfoundation/nuts-node:master}` (and `B` for the second node) image. 
  This only applied to images that should be replaced during automated testing),
- [x] it can be run with a `run-test.sh` script that is called from _all_ appropriate `run-tests.sh` scripts