### PR TITLE
OpenID4VCI: is now bound as /n2n endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ When there are multiple in a test, some will use `IMAGE_NODE_A` and the other `I
 Since tests are asymmetric (the action is only performed from node A to B), you want to run the tests twice with the image variables swapped, e.g.:
 
 ```console
-$ IMAGE_NODE_A=nutsfoundation/nuts-node:local \
-IMAGE_NODE_B=nutsfoundation/nuts-node:local \
+$ IMAGE_NODE_A=nutsfoundation/nuts-node:v4.3.0 \
+IMAGE_NODE_B=nutsfoundation/nuts-node:v5.0.0 \
 ./run-tests.sh
 ```
 

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ When there are multiple in a test, some will use `IMAGE_NODE_A` and the other `I
 Since tests are asymmetric (the action is only performed from node A to B), you want to run the tests twice with the image variables swapped, e.g.:
 
 ```console
-$ IMAGE_NODE_A=nutsfoundation/nuts-node:v4.3.0 \
-IMAGE_NODE_B=nutsfoundation/nuts-node:v5.0.0 \
+$ IMAGE_NODE_A=nutsfoundation/nuts-node:local \
+IMAGE_NODE_B=nutsfoundation/nuts-node:local \
 ./run-tests.sh
 ```
 

--- a/openid4vci/issuer-initiated/node-A/nuts.yaml
+++ b/openid4vci/issuer-initiated/node-A/nuts.yaml
@@ -10,7 +10,7 @@ http:
       address: :443
       tls: server-client
 auth:
-  publicurl: https://nodeA:1323
+  publicurl: http://nodeA:1323
   contractvalidators:
     - dummy
   irma:
@@ -21,7 +21,7 @@ vcr:
   overrideissueallpublic: false
   oidc4vci:
     enabled: true
-    url: https://nodeA:443
+    url: https://nodeA
 tls:
   truststorefile: /opt/nuts/truststore.pem
   certfile: /opt/nuts/certificate-and-key.pem

--- a/openid4vci/issuer-initiated/node-A/nuts.yaml
+++ b/openid4vci/issuer-initiated/node-A/nuts.yaml
@@ -5,8 +5,12 @@ datadir: /opt/nuts/data
 http:
   default:
     address: :1323
+  alt:
+    n2n:
+      address: :443
+      tls: server-client
 auth:
-  publicurl: http://nodeA:1323
+  publicurl: https://nodeA:1323
   contractvalidators:
     - dummy
   irma:
@@ -17,7 +21,7 @@ vcr:
   overrideissueallpublic: false
   oidc4vci:
     enabled: true
-    url: http://nodeA:1323
+    url: https://nodeA:443
 tls:
   truststorefile: /opt/nuts/truststore.pem
   certfile: /opt/nuts/certificate-and-key.pem

--- a/openid4vci/issuer-initiated/node-B/nuts.yaml
+++ b/openid4vci/issuer-initiated/node-B/nuts.yaml
@@ -5,8 +5,12 @@ datadir: /opt/nuts/data
 http:
   default:
     address: :1323
+  alt:
+    n2n:
+      address: :443
+      tls: server-client
 auth:
-  publicurl: http://nodeB:1323
+  publicurl: https://nodeB:1323
   contractvalidators:
     - dummy
   irma:
@@ -17,7 +21,7 @@ vcr:
   overrideissueallpublic: false
   oidc4vci:
     enabled: true
-    url: http://nodeB:1323
+    url: https://nodeB:443
 tls:
   truststorefile: /opt/nuts/truststore.pem
   certfile: /opt/nuts/certificate-and-key.pem

--- a/openid4vci/issuer-initiated/node-B/nuts.yaml
+++ b/openid4vci/issuer-initiated/node-B/nuts.yaml
@@ -10,7 +10,7 @@ http:
       address: :443
       tls: server-client
 auth:
-  publicurl: https://nodeB:1323
+  publicurl: http://nodeB:1323
   contractvalidators:
     - dummy
   irma:
@@ -21,7 +21,7 @@ vcr:
   overrideissueallpublic: false
   oidc4vci:
     enabled: true
-    url: https://nodeB:443
+    url: https://nodeB
 tls:
   truststorefile: /opt/nuts/truststore.pem
   certfile: /opt/nuts/certificate-and-key.pem

--- a/openid4vci/issuer-initiated/run-test.sh
+++ b/openid4vci/issuer-initiated/run-test.sh
@@ -32,7 +32,7 @@ waitForTXCount "NodeB" "http://localhost:21323/status/diagnostics" 2 10
 
 didNodeB=$(setupNode "http://localhost:21323" "nodeB:5555")
 printf "NodeDID for node-b: %s\n" "$didNodeB"
-registerStringService "http://localhost:21323" "$didNodeB" "oidc4vci-wallet-metadata" "http://nodeB:1323/identity/$didNodeB/.well-known/openid-credential-wallet"
+registerStringService "http://localhost:21323" "$didNodeB" "oidc4vci-wallet-metadata" "https://nodeB:443/n2n/identity/$didNodeB/.well-known/openid-credential-wallet"
 
 # Wait for node A to receive all TXs created by node B
 waitForTXCount "NodeA" "http://localhost:11323/status/diagnostics" 5 10

--- a/openid4vci/issuer-initiated/run-test.sh
+++ b/openid4vci/issuer-initiated/run-test.sh
@@ -32,7 +32,7 @@ waitForTXCount "NodeB" "http://localhost:21323/status/diagnostics" 2 10
 
 didNodeB=$(setupNode "http://localhost:21323" "nodeB:5555")
 printf "NodeDID for node-b: %s\n" "$didNodeB"
-registerStringService "http://localhost:21323" "$didNodeB" "oidc4vci-wallet-metadata" "https://nodeB:443/n2n/identity/$didNodeB/.well-known/openid-credential-wallet"
+registerStringService "http://localhost:21323" "$didNodeB" "oidc4vci-wallet-metadata" "https://nodeB/n2n/identity/$didNodeB/.well-known/openid-credential-wallet"
 
 # Wait for node A to receive all TXs created by node B
 waitForTXCount "NodeA" "http://localhost:11323/status/diagnostics" 5 10


### PR DESCRIPTION
Companion PR of https://github.com/nuts-foundation/nuts-node/pull/2145